### PR TITLE
Fix broken thumbnails in the backend

### DIFF
--- a/Classes/Driver/StorageDriver.php
+++ b/Classes/Driver/StorageDriver.php
@@ -161,6 +161,10 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
      */
     public function getPublicUrl($identifier)
     {
+        $uriParts = GeneralUtility::trimExplode('/', ltrim($identifier, '/'), true);
+        $uriParts = array_map('rawurlencode', $uriParts);
+        $identifier = implode('/', $uriParts);
+
         if (!is_null($this->endpoint)) {
             if (substr($this->endpoint, -1) === '/') {
                 $url = $this->protocol . '://' . $this->endpoint . $this->container . '/' . $identifier;


### PR DESCRIPTION
This fixes broken thumbnails when having space or utf-8 characters in the filename.

Fixes: https://github.com/benjaminhirsch/typo3-azurestorage/issues/1

Inspired by https://github.com/andersundsehr/aus_driver_amazon_s3/blob/master/Classes/Driver/AmazonS3Driver.php#L160