### PR TITLE
Fixed missing usage of $propertiesToExtract in StorageDriver::getFileInfoByIdentifier()

### DIFF
--- a/Classes/Driver/StorageDriver.php
+++ b/Classes/Driver/StorageDriver.php
@@ -696,7 +696,7 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
             $fileInfo['mimetype'] = $properties->getContentType();
         }
 
-        $properties =  array_merge($fileInfo, [
+        $properties = array_merge($fileInfo, [
             'identifier' => $fileIdentifier,
             'name' => basename(rtrim($fileIdentifier, '/')),
             'storage' => $this->storageUid,

--- a/Classes/Driver/StorageDriver.php
+++ b/Classes/Driver/StorageDriver.php
@@ -696,7 +696,7 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
             $fileInfo['mimetype'] = $properties->getContentType();
         }
 
-        $properties =  array_merge($fileInfo, [
+        $fileInfo = array_merge($fileInfo, [
             'identifier' => $fileIdentifier,
             'name' => basename(rtrim($fileIdentifier, '/')),
             'storage' => $this->storageUid,
@@ -705,13 +705,13 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
             'mtime' => $properties->getLastModified()->format('U'),
         ]);
 
-        $returnPropertiesToExtract = [];
+        $fileInfoToExtract = [];
 
-        foreach ($propertiesToExtract as $property) {
-            $returnPropertiesToExtract[$property] = $properties[$property];
+        foreach ($propertiesToExtract as $propertyName) {
+            $fileInfoToExtract[$propertyName] = $fileInfo[$propertyName];
         }
 
-        return $returnPropertiesToExtract ?: $properties;
+        return $fileInfoToExtract ?: $fileInfo;
     }
 
     /**

--- a/Classes/Driver/StorageDriver.php
+++ b/Classes/Driver/StorageDriver.php
@@ -694,10 +694,9 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
             $properties = $blob->getProperties();
             $fileInfo['size'] = $properties->getContentLength();
             $fileInfo['mimetype'] = $properties->getContentType();
-
         }
 
-        return array_merge($fileInfo, [
+        $properties =  array_merge($fileInfo, [
             'identifier' => $fileIdentifier,
             'name' => basename(rtrim($fileIdentifier, '/')),
             'storage' => $this->storageUid,
@@ -705,6 +704,14 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
             'folder_hash' => $this->hashIdentifier($this->getParentFolderIdentifierOfIdentifier($fileIdentifier)),
             'mtime' => $properties->getLastModified()->format('U'),
         ]);
+
+        $returnPropertiesToExtract = [];
+
+        foreach ($propertiesToExtract as $property) {
+            $returnPropertiesToExtract[$property] = $properties[$property];
+        }
+
+        return $returnPropertiesToExtract ?: $properties;
     }
 
     /**


### PR DESCRIPTION
See Issue #32 