### PR TITLE
improved/removed deprecated code

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -23,8 +23,8 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
         ],
     );
 }
-
-\TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::getInstance()->registerExtractionService(\B3N\AzureStorage\TYPO3\Index\Extractor::class);
+$extractorRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::class);
+$extractorRegistry->registerExtractionService(\B3N\AzureStorage\TYPO3\Index\Extractor::class);
 
 /* @var $signalSlotDispatcher \TYPO3\CMS\Extbase\SignalSlot\Dispatcher */
 $signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);


### PR DESCRIPTION
ExtractorRegistry->getInstance()  will be removed in TYPO3 v12.0. Deprecation warning solved