### PR TITLE
TYPO3 12 compatibility

### DIFF
--- a/Classes/EventListener/AfterFileAddedToIndex.php
+++ b/Classes/EventListener/AfterFileAddedToIndex.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B3N\AzureStorage\TYPO3\EventListener;
+
+use TYPO3\CMS\Core\Resource\Event\AfterFileAddedToIndexEvent;
+
+class AfterFileAddedToIndex extends AbstractFileIndexEventListener
+{
+    public function __invoke(AfterFileAddedToIndexEvent $event): void
+    {
+        $this->recordUpdatedOrCreated($event->getRecord());
+    }
+}

--- a/Classes/EventListener/AfterFileUpdatedInIndex.php
+++ b/Classes/EventListener/AfterFileUpdatedInIndex.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace B3N\AzureStorage\TYPO3\EventListener;
+
+use TYPO3\CMS\Core\Resource\Event\AfterFileUpdatedInIndexEvent;
+
+class AfterFileUpdatedInIndex extends AbstractFileIndexEventListener
+{
+    public function __invoke(AfterFileUpdatedInIndexEvent $event): void
+    {
+        $this->recordUpdatedOrCreated($event->getRelevantProperties());
+    }
+}

--- a/Configuration/Services.yaml
+++ b/Configuration/Services.yaml
@@ -1,0 +1,18 @@
+services:
+  _defaults:
+    autowire: true
+    autoconfigure: true
+    public: false
+
+  B3N\AzureStorage\TYPO3\:
+    resource: '../Classes/*'
+
+  B3N\AzureStorage\TYPO3\EventListener\AfterFileAddedToIndex:
+    tags:
+      - name: event.listener
+        identifier: 'azurestorage/after-file-added-to-index'
+
+  B3N\AzureStorage\TYPO3\EventListener\AfterFileUpdatedInIndex:
+    tags:
+      - name: event.listener
+        identifier: 'azurestorage/after-file-updated-in-index'

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "MIT"
   ],
   "require": {
-    "typo3/cms-core": "^11.5 || ^12.0",
+    "typo3/cms-core": ">=11.5.0",
     "microsoft/azure-storage-blob": "^1.2.0"
   },
   "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
     "MIT"
   ],
   "require": {
-    "typo3/cms-core": ">=11.5.0",
+    "typo3/cms-core": "^11.5 || ^12.0",
     "microsoft/azure-storage-blob": "^1.2.0"
   },
   "autoload": {

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -24,8 +24,3 @@ if (!isset($GLOBALS['TYPO3_CONF_VARS']['SYS']['caching']['cacheConfigurations'][
 }
 $extractorRegistry = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Core\Resource\Index\ExtractorRegistry::class);
 $extractorRegistry->registerExtractionService(\B3N\AzureStorage\TYPO3\Index\Extractor::class);
-
-/* @var $signalSlotDispatcher \TYPO3\CMS\Extbase\SignalSlot\Dispatcher */
-$signalSlotDispatcher = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(\TYPO3\CMS\Extbase\SignalSlot\Dispatcher::class);
-$signalSlotDispatcher->connect(\TYPO3\CMS\Core\Resource\Index\FileIndexRepository::class, 'recordUpdated', \B3N\AzureStorage\TYPO3\Signal\FileIndexRepository::class, 'recordUpdatedOrCreated');
-$signalSlotDispatcher->connect(\TYPO3\CMS\Core\Resource\Index\FileIndexRepository::class, 'recordCreated', \B3N\AzureStorage\TYPO3\Signal\FileIndexRepository::class, 'recordUpdatedOrCreated');


### PR DESCRIPTION
This merge request contains two changes:

## 1) Replace SignalSlot implementation by Events

There was a remaining SignalSlot implementation left, which did not work in TYPO3 12 anymore and resulted in an error, because `\TYPO3\CMS\Extbase\SignalSlot\Dispatcher` does not exist anymore.

Looks like the SignalSlot implementation did not work for several TYPO3 reasons. Because the signals already have been removed in the core long time ago. But nevertheless, it's good to have the feature brought back to have correct dimensions for uploaded files.

## 2) Fix composer constraint

`"typo3/cms-core": ">=11.5.0"` says "any version since 11.5.0, no matter if it is TYPO3 12, TYPO 13 or TYPO3 99 ... I changed it to the more precise constraint `"typo3/cms-core": "^11.5 || ^12.0"` which limits it to TYPO3 11.*.* or 12.*.* - the same as it is mentioned in `ext_emconf.php`.