### PR TITLE
Remove usage of GeneralUtility::isFirstPartOfStr()

### DIFF
--- a/Classes/Driver/StorageDriver.php
+++ b/Classes/Driver/StorageDriver.php
@@ -659,7 +659,7 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
             return true;
         }
 
-        return GeneralUtility::isFirstPartOfStr($identifier, $folderIdentifier);
+        return str_starts_with($identifier, $folderIdentifier);
     }
 
     /**


### PR DESCRIPTION
GeneralUtility::isFirstPartOfStr() was deprecated in https://forge.typo3.org/issues/95257 and removed in https://forge.typo3.org/issues/96107