### PR TITLE
mtime is expected to be an int

### DIFF
--- a/Classes/Driver/StorageDriver.php
+++ b/Classes/Driver/StorageDriver.php
@@ -716,7 +716,7 @@ class StorageDriver extends AbstractHierarchicalFilesystemDriver
             'storage' => $this->storageUid,
             'identifier_hash' => $this->hashIdentifier($fileIdentifier),
             'folder_hash' => $this->hashIdentifier($this->getParentFolderIdentifierOfIdentifier($fileIdentifier)),
-            'mtime' => $properties->getLastModified()->format('U'),
+            'mtime' => (int)$properties->getLastModified()->format('U'),
         ]);
 
         $fileInfoToExtract = [];


### PR DESCRIPTION
Else it throws an error when a file already exists in the typo3 backend. 

<img width="696" height="185" alt="image" src="https://github.com/user-attachments/assets/bd7c12a6-63a8-4c35-9439-19786ad3654e" />

<img width="696" height="185" alt="image" src="https://github.com/user-attachments/assets/8c31ddbf-e330-4e6b-b547-e415351e444b" />
